### PR TITLE
Limit package to CheckMK 2.2.0

### DIFF
--- a/package
+++ b/package
@@ -82,6 +82,6 @@
     "title": "CheckMK FortiOS",
     "version": "1.0.0",
     "version.min_required": "2.2.0p1",
-    "version.usable_until": None,
+    "version.usable_until": 2.3.0b1,
     "version.packaged": "2.2.0p31",
 }


### PR DESCRIPTION
Set the maximum version, as the package is not suitable for CheckMK 2.3.0.