### PR TITLE
Initial fixes for 2.3 compatibility

### DIFF
--- a/agent_based/fortios_device_info_inventory.py
+++ b/agent_based/fortios_device_info_inventory.py
@@ -30,10 +30,10 @@ from cmk.base.plugins.agent_based.agent_based_api.v1 import (
     register,
 )
 from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import InventoryResult
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
-class ModelInfo(BaseModel):
+class ModelInfo(BaseModel,protected_namespaces = ()):
     hostname: str
     model_name: str
     model: str
@@ -45,6 +45,13 @@ class DeviceInfo(BaseModel):
     version: str
     build: str
     results: Optional[ModelInfo] = None
+
+    @field_validator('build', mode='before')
+    @classmethod
+    def stringify(cls, value) -> str:
+        if value is not None:
+            return str(value)
+        return value
 
 
 _MANUFACTURER = "Fortinet"

--- a/agent_based/fortios_interface.py
+++ b/agent_based/fortios_interface.py
@@ -44,7 +44,7 @@ from cmk.base.plugins.agent_based.agent_based_api.v1.render import (
     nicspeed,
 )
 from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import CheckResult, DiscoveryResult
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, RootModel, validator
 
 
 class Interface(BaseModel):
@@ -68,7 +68,7 @@ class Interface(BaseModel):
     vlanid: Optional[int] = None
     interface: Optional[str] = None
     vdom: Optional[str] = None
-    description: Optional[str]
+    description: Optional[str] = None
     interface_type: Optional[str] = None
 
     # convert bytes to bps
@@ -103,11 +103,11 @@ class VdomData(BaseModel):
         return v
 
 
-class VdomDataList(BaseModel):
-    __root__: List[VdomData]
+class VdomDataList(RootModel):
+    root: List[VdomData]
 
 
-VdomDataList.update_forward_refs()
+VdomDataList.model_rebuild()
 
 
 class Duplex(IntEnum):
@@ -129,10 +129,10 @@ def parse_fortios_interfaces(string_table):
     except (ValueError, IndexError):
         return None
 
-    data = VdomDataList.parse_obj(json_data)
+    data = VdomDataList.model_validate(json_data)
 
     combined_results = {}
-    for vdom_data in data.__root__:
+    for vdom_data in data.root:
         combined_results.update(vdom_data.results)
     return combined_results
 

--- a/agent_based/fortios_interface_cmdb.py
+++ b/agent_based/fortios_interface_cmdb.py
@@ -27,7 +27,7 @@ import json
 from typing import List, Optional
 
 from cmk.base.plugins.agent_based.agent_based_api.v1 import register
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class InterfaceCMDB(BaseModel):
@@ -76,6 +76,13 @@ class InterfaceCMDB(BaseModel):
     vrf: Optional[int]
     wccp: Optional[str]
     weight: Optional[int]
+
+    @field_validator('internal', mode='before')
+    @classmethod
+    def stringify(cls, value) -> str:
+        if value is not None:
+            return str(value)
+        return value
 
 
 def parse_fortios_interfaces_cmdb(string_table):

--- a/agent_based/fortios_license.py
+++ b/agent_based/fortios_license.py
@@ -219,10 +219,10 @@ class LicenseStatus(BaseModel):
 
 def parse_fortios_license(string_table) -> Mapping[str, str] | None:
     try:
-        json_data = json.loads(string_table[0][0])
+        json_data = json.loads(string_table[0][0])        
     except ValueError:
-        json_data = {}
-
+        json_data = {} # Just defers the crash to line 226       
+    
     license_modules = LicenseStatus(**json_data)
 
     return {key: item for key, item in license_modules.results.items()}

--- a/agent_based/fortios_license.py
+++ b/agent_based/fortios_license.py
@@ -73,7 +73,11 @@ class FortiGuardModule(ModuleInterface):
 
     @property
     def summary(self):
-        next_scheduled_update = render.timespan(self.next_scheduled_update - time.time())
+        ts = self.next_scheduled_update - time.time()
+        if ts < 0:
+            next_scheduled_update = "overdue" # Prevent crashes with testdata and negative timespan
+        else:
+            next_scheduled_update = render.timespan(ts)
         return f'Supported: {self.supported} WAN IP: {self.fortigate_wan_ip}, Scheduled Update: {self.scheduled_updates_enabled}, Next update: {next_scheduled_update}'
 
 class SupportDetail(BaseModel):

--- a/agent_based/fortios_managed_switch.py
+++ b/agent_based/fortios_managed_switch.py
@@ -32,7 +32,7 @@ from cmk.base.plugins.agent_based.agent_based_api.v1 import (
     register,
 )
 from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import CheckResult, DiscoveryResult
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class Switch(BaseModel, frozen=True):
@@ -51,6 +51,14 @@ class Switch(BaseModel, frozen=True):
     mc_lag_supported: bool
     led_blink_supported: bool
     os_version: str
+
+    @field_validator('is_l3', mode='before')
+    @classmethod
+    def stringify(cls, value) -> str:
+        if value is not None:
+            return str(value)
+        return value
+
 
     @property
     def summary(self) -> str:

--- a/agent_based/fortios_managed_switch.py
+++ b/agent_based/fortios_managed_switch.py
@@ -77,7 +77,12 @@ def parse_fortios_managed_switch(string_table) -> Mapping[str, Switch] | None:
 
     if (forti_switches := json_data.get("results")) in ({}, []):
         return None
-
+        
+    for item in forti_switches:
+        # Latest firmware update renamed field?
+        if item.get("name") is None:
+            item["name"] = item["switch-id"]
+    
     return {item["name"]: Switch(**item) for item in forti_switches}
 
 

--- a/agent_based/fortios_managed_switch_interface.py
+++ b/agent_based/fortios_managed_switch_interface.py
@@ -61,7 +61,7 @@ class InterfaceData(BaseModel):
 
 class PhysicalPort(BaseModel):
     access_mode: str
-    admin_vlan: Optional[str]
+    admin_vlan: Optional[str] = None
     aggregator_mode: str
     allowed_vlans_all: str
     arp_inspection_trust: str
@@ -104,12 +104,12 @@ class PhysicalPort(BaseModel):
     packet_sampler: str
     pause_meter: int
     pause_meter_resume: str
-    poe_capable: Optional[int]
+    poe_capable: Optional[int] = None
     poe_max_power: str
     poe_pre_standard_detection: str
     poe_standard: str
-    poe_status: Optional[str]
-    poe_: Optional[str]
+    poe_status: Optional[str] = None
+    poe_: Optional[str] = None
     port_name: str
     port_number: int
     port_owner: str
@@ -123,10 +123,10 @@ class PhysicalPort(BaseModel):
     rpvst_port: str
     sample_direction: str
     sflow_counter_interval: int
-    speed: Optional[Union[str, int]]
+    speed: Optional[Union[str, int]] = None
     speed_mask: int
     stacking_port: int
-    status: Optional[str]
+    status: Optional[str] = None
     sticky_mac: str
     storm_control_policy: str
     stp_bpdu_guard: str
@@ -137,29 +137,29 @@ class PhysicalPort(BaseModel):
     trunk_member: int
     type: str
     virtual_port: int
-    vlan: Optional[str]
-    collisions: int
-    crc_alignments: int
-    fragments: int
-    jabbers: int
-    l3packets: int
-    rx_bcast: int
-    rx_bytes: int
-    rx_drops: int
-    rx_errors: int
-    rx_mcast: int
-    rx_oversize: int
-    rx_packets: int
-    rx_ucast: int
-    tx_bcast: int
-    tx_bytes: int
-    tx_drops: int
-    tx_errors: int
-    tx_mcast: int
-    tx_oversize: int
-    tx_packets: int
-    tx_ucast: int
-    undersize: int
+    vlan: Optional[str] = None
+    collisions: Optional[int] = None
+    crc_alignments: Optional[int] = None
+    fragments: Optional[int] = None
+    jabbers: Optional[int] = None
+    l3packets: Optional[int] = None
+    rx_bcast: Optional[int] = None
+    rx_bytes: Optional[int] = None
+    rx_drops: Optional[int] = None
+    rx_errors: Optional[int] = None
+    rx_mcast: Optional[int] = None
+    rx_oversize: Optional[int] = None
+    rx_packets: Optional[int] = None
+    rx_ucast: Optional[int] = None
+    tx_bcast: Optional[int] = None
+    tx_bytes: Optional[int] = None
+    tx_drops: Optional[int] = None
+    tx_errors: Optional[int] = None
+    tx_mcast: Optional[int] = None
+    tx_oversize: Optional[int] = None
+    tx_packets: Optional[int] = None
+    tx_ucast: Optional[int] = None
+    undersize: Optional[int] = None
     duplex: Optional[str] = None
     port_status: Optional[str] = None
     igmp_snooping_group: Optional[IgmpSnoopingGroup] = None
@@ -262,7 +262,11 @@ def check_fortios_switch_interface(item: str, section: Mapping[str, PhysicalPort
 
     for key in ["rx_bytes", "tx_bytes", "tx_mcast", "tx_bcast", "rx_mcast", "rx_bcast", "rx_errors", "tx_errors", "tx_drops", "rx_drops", "collisions", "crc_alignments"]:
         if hasattr(interface, key):
-            attribute = getattr(interface, key)
+            attribute = getattr(interface, key)            
+            # e.g. LACP-ports do not seem to provide any of the possible values for key, therefore skip
+            if attribute is None: 
+                continue
+
             value = 0
             try:
                 value = get_rate(value_store, f"{key}", time_now, attribute, raise_overflow=False)

--- a/agents/special/agent_fortios
+++ b/agents/special/agent_fortios
@@ -29,12 +29,12 @@ from typing import Optional
 
 import requests
 import urllib3
-from cmk.special_agents.utils.agent_common import (
+from cmk.special_agents.v0_unstable.agent_common  import (
     ConditionalPiggybackSection,
     SectionWriter,
     special_agent_main,
 )
-from cmk.special_agents.utils.argument_parsing import Args, create_default_argument_parser
+from cmk.special_agents.v0_unstable.argument_parsing import Args, create_default_argument_parser
 from requests.adapters import HTTPAdapter
 
 _LOGGER = logging.getLogger("agent_fortios")
@@ -341,9 +341,13 @@ def agent_fortios(args: Args) -> int:
         
         except Exception:
             _LOGGER.error(f"Collecting {spec.name} failed: {spec.path}")
+            sys.stdout.write("\n<<<>>>\n") # Hotfix: End previous-section. SectionError appends the error output to a working section otherwise. 
+                                           # CorrectSolution: SectionWriter+co should close its section on __exit__
             SectionError(f"Section error for spec: {spec.name} with path: {spec.path}")
             if args.debug:
                 return 1
+            else:
+                continue  # data still contains values from earlier _spec, so w/o continue data gets outputed in wrong section
 
         # piggybackdata handling
         if spec.piggyback and spec.piggyback_section == "switch":

--- a/package
+++ b/package
@@ -82,6 +82,5 @@
     "title": "CheckMK FortiOS",
     "version": "1.0.0",
     "version.min_required": "2.2.0p1",
-    "version.usable_until": 2.3.0b1,
     "version.packaged": "2.2.0p31",
 }

--- a/web/plugins/views/fortios_inventory.py
+++ b/web/plugins/views/fortios_inventory.py
@@ -27,7 +27,7 @@ from cmk.gui.type_defs import (
     VisualLinkSpec,
 )
 from cmk.gui.views.store import multisite_builtin_views
-from cmk.utils.type_defs import UserId
+from cmk.utils.user import UserId
 
 multisite_builtin_views.update(
     {


### PR DESCRIPTION
## Summary

These ares some fixes to make the plugin run on Checkmk 2.3,
but those are not well tested yet.

Most changes are related to changes in pydantic. Some are related to 
changed imports. A change in the special-agent itself prevents possible 
errors being appended to the previous, correctly processed section.

## Pull request type

Please check the type of change your PR introduces (please delete not used lines):

- [X] Bugfix
- [X] Feature


