### PR TITLE
crash fixed if license is not active

### DIFF
--- a/agent_based/fortios_license.py
+++ b/agent_based/fortios_license.py
@@ -144,7 +144,7 @@ class AppCtrlModule(ModuleInterface):
 class WebFilteringModule(ModuleInterface):
     type: str = "live_fortiguard_service"
     status: str
-    expires: int
+    expires: Optional[int] = None # Optional, as it is not present if license is not active
     entitlement: str
     category_list_version: int
     running: bool
@@ -286,8 +286,14 @@ def check_fortios_license(item: str, params: Mapping[str, Any], section: Mapping
                 levels_lower=day_levels,
                 render_func=lambda v: f"{v:.0f} days",
             )
-
-        yield Metric("expires", convert_number_of_days(license.expires), levels=day_levels)
+        else:
+            yield Result(
+                state=State.OK,
+                summary=(f"Status: {license.status}, Entitlement: {license.entitlement}, "
+                         f"Running: {license.running}"),
+            )
+        if license.expires is not None and str(license.expires).isdigit():
+            yield Metric("expires", convert_number_of_days(license.expires), levels=day_levels)
 
     elif item == "appctrl":
         if license.status == "licensed":


### PR DESCRIPTION
## Summary

If a license is not active you get a crash at discovery time with an pydantic error.
The "expires" value is not existing in this case.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces (please delete not used lines):

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Pytests
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

After the change in the discovery function - the license was discovered but then you get an crash at check time.
As it is not possible to convert "None" to days.
This is fixed with the extension to the check function.

### Screenshots (if appropriate):


## Checklist

### Open tasks (PR specific):
* [ ] Task 1
* [ ] Task 2

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WagnerAG/checkmk_fortigate/pulls) for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have made corresponding changes to the documentation

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally before submission?