### PR TITLE
Internal error: 'main_menu_search_terms'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 > The format is based on [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 
 ---
-## [2.5.0] - 2026-07-08
+## [2.5.1] - 2026-07-28
+### 🐛 Fixed
+- Fixed inventory gui config, thanks to @FabianBinder for the work
 
+## [2.5.0] - 2026-07-08
 ### 🔄 Changed
 - Due to compatibility issues, this project maintains two separate release tracks:
     - CheckMK 2.5.x → main branch → FortiOS Plugin name: v2.5.x

--- a/lib/gui/plugins/views/fortios_inventory.py
+++ b/lib/gui/plugins/views/fortios_inventory.py
@@ -111,7 +111,7 @@ multisite_builtin_views.update(
                 "has_inv": {"is_has_inv": "1"},
             },
             "owner": UserId.builtin(),
-            "megamenu_search_terms": [],
+            "main_menu_search_terms": [],
         },
     }
 )

--- a/package
+++ b/package
@@ -84,7 +84,7 @@
     },
     "name": "fortios",
     "title": "FortiOS Special Agent",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "version.min_required": "2.5.0p1",
     "version.packaged": "cmk-mkp-tool 1.0.0",
     "version.usable_until": "2.6.0b1",


### PR DESCRIPTION
## Summary

The MKP crashes the whole UI after installing it in Checkmk 2.5.0, due to an outdated view definition. To reproduce, install the MKP and refresh the browser cache or re-login in a private browser window. "megamenu_search_terms" has been renamed to "main_menu_search_terms" to fix this issue.

## Pull request type

Please check the type of change your PR introduces (please delete not used lines):

- [x] Bugfix


## What is the current behavior?

Error message "Internal error: 'main_menu_search_terms'" after installing the MKP and refreshing the browser cache (or re-login in private browser window)


## What is the new behavior?

Error message does not occur anymore


## Other information


### Screenshots (if appropriate):


## Checklist

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WagnerAG/checkmk_fortigate/pulls) for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have made corresponding changes to the documentation

